### PR TITLE
Allow add a file name sufix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Available setting for Logger are:
 path:
 (string) The relative or absolute filesystem path to a writable directory.
 
+name:
+(string) The log file name (Prefix file name).
+
 name_format:
 (string) The log file name format; parsed with `date()`.
 
@@ -120,6 +123,7 @@ $container['logger'] = function($c) {
   return new Silalahi\Slim\Logger(
     [
       'path' => '.',
+      'name' => 'app_logger_',
       'name_format' => 'Y-m-d',
       'extension' => '.txt',
       'message_format' => '[%label%] %date% %message%'

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -40,6 +40,9 @@ class Logger {
      * path:
      * (string) The relative or absolute filesystem path to a writable directory.
      *
+     * name:
+     * (string) The log file name (Prefix file name).
+     *
      * name_format:
      * (string) The log file name format; parsed with `date()`.
      *
@@ -60,6 +63,7 @@ class Logger {
         // Merge settings
         $this->settings =  array_merge(array(
             'path' => '.',
+            'name' => 'logger_',
             'name_format' => 'Y-m-d',
             'extension' => 'log',
             'message_format' => '[%label%] %date% %message%'
@@ -138,7 +142,8 @@ class Logger {
         );
 
         if ( ! $this->resource) {
-            $filename = date($this->settings['name_format']);
+            $filename = $this->settings['name'];
+            $filename .= date($this->settings['name_format']);
             if (! empty($this->settings['extension'])) {
                 $filename .= '.' . $this->settings['extension'];
             }


### PR DESCRIPTION
This pull request allow users add a name prefix and not just use the date format, so you can get (Just an example):
myownlog_2016-09-03.txt

In this way we can manage different log names =)
